### PR TITLE
Cleanup views_accordion_style_plugin.inc

### DIFF
--- a/views_accordion_style_plugin.inc
+++ b/views_accordion_style_plugin.inc
@@ -10,21 +10,6 @@
 class views_accordion_style_plugin extends views_plugin_style {
 
   /**
-   * Whether or not jquery is higher than 1.9.
-   *
-   * Accordion options format changed for jquery >= 1.9
-   *
-   * @var bool
-   */
-
-  /**
-   * {@inheritdoc}
-   */
-  public function init(&$view, &$display, $options = NULL) {
-    parent::init($view, $display, $options);
-  }
-
-  /**
    * Set default options.
    */
   public function option_definition() {


### PR DESCRIPTION
Just a cleanup after https://www.drupal.org/project/views_accordion/issues/1675010

- The `init()` method is no longer necessary since we don't need to check jQuery versions lower than 1.9
- Removes the docblock for the unnecessary `$newoptions` property